### PR TITLE
Remove node from zerotier Central when leaving network

### DIFF
--- a/libraries/zerotier_network.rb
+++ b/libraries/zerotier_network.rb
@@ -66,6 +66,15 @@ module ChefZerotierCookbook
                     leave.run_command
                     raise format("Error leaving network %s", network_id) if leave.error?
                 end
+
+                if auth_token
+                    url = URI.parse(format("%s/api/network/%s/member/%s/", central_url, network_id, node['zerotier']['node_id']))
+                    response = Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == "https") do |http|
+                        delete = Net::HTTP::Delete.new(url, "Content-Type" => "application/json")
+                        delete.add_field("Authorization", format("Bearer %s", auth_token))
+                        http.request(delete)
+                    end
+                end
             else
                 Chef::Log.warn(format("Network %s is not joined. Skipping", network_id))
             end

--- a/libraries/zerotier_network.rb
+++ b/libraries/zerotier_network.rb
@@ -32,6 +32,7 @@ module ChefZerotierCookbook
                         networkId: network_id,
                         nodeId: node["zerotier"]["node_id"],
                         name: node_name,
+                        hidden: false,
                         config: {
                             nwid: network_id,
                             authorized: true


### PR DESCRIPTION
When leaving network, the node is still exists in zerotier Central, so I added api call to delete it completely