### PR TITLE
Fix Namespace Collision

### DIFF
--- a/libraries/zerotier_network.rb
+++ b/libraries/zerotier_network.rb
@@ -18,29 +18,29 @@ module ChefZerotierCookbook
         property :central_url, String, default: "https://my.zerotier.com"
 
         action :join do
-            if ::File.exists?(format("/var/lib/zerotier-one/networks.d/%s.conf", network_id))
-                Chef::Log.info(format("Network %s already joined. Skipping.", network_id))
+            if ::File.exists?(format("/var/lib/zerotier-one/networks.d/%s.conf", new_resource.network_id))
+                Chef::Log.info(format("Network %s already joined. Skipping.", new_resource.network_id))
             else
-                join = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli join %s", network_id))
+                join = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli join %s", new_resource.network_id))
                 join.run_command
-                raise format("Error joining network %s", network_id) if join.error?
+                raise format("Error joining network %s", new_resource.network_id) if join.error?
 
-                if auth_token
-                    url = URI.parse(format("%s/api/network/%s/member/%s/", central_url, network_id, node['zerotier']['node_id']))
-                   
+                if new_resource.auth_token
+                    url = URI.parse(format("%s/api/network/%s/member/%s/", new_resource.central_url, new_resource.network_id, node['zerotier']['node_id']))
+
                     netinfo = {
-                        networkId: network_id,
+                        networkId: new_resource.network_id,
                         nodeId: node["zerotier"]["node_id"],
-                        name: node_name,
+                        name: new_resource.node_name,
                         config: {
-                            nwid: network_id,
+                            nwid: new_resource.network_id,
                             authorized: true
                         }
                     }
 
                     response = Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == "https") do |http|
                         post = Net::HTTP::Post.new(url, "Content-Type" => "application/json")
-                        post.add_field("Authorization", format("Bearer %s", auth_token))
+                        post.add_field("Authorization", format("Bearer %s", new_resource.auth_token))
                         post.body = netinfo.to_json
                         http.request(post)
                     end
@@ -49,25 +49,25 @@ module ChefZerotierCookbook
                     when Net::HTTPSuccess
                         # do nothing
                     else
-                        leave = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli leave %s", network_id))
+                        leave = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli leave %s", new_resource.network_id))
                         leave.run_command
                         error = JSON.parse(response.body)
                         raise format("Error %s authorizing network: %s: %s", response.code. error["type"], error["message"])
                     end
                 end
-                
+
             end
         end
 
         action :leave do
-            if ::File.exists?(format("/var/lib/zerotier-one/networks.d/%s.conf", network_id))
-                converge_by(format("Leaving network %s", network_id)) do
-                    leave = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli leave %s", network_id))
+            if ::File.exists?(format("/var/lib/zerotier-one/networks.d/%s.conf", new_resource.network_id))
+                converge_by(format("Leaving network %s", new_resource.network_id)) do
+                    leave = Mixlib::ShellOut.new(format("/usr/sbin/zerotier-cli leave %s", new_resource.network_id))
                     leave.run_command
-                    raise format("Error leaving network %s", network_id) if leave.error?
+                    raise format("Error leaving network %s", new_resource.network_id) if leave.error?
                 end
             else
-                Chef::Log.warn(format("Network %s is not joined. Skipping", network_id))
+                Chef::Log.warn(format("Network %s is not joined. Skipping", new_resource.network_id))
             end
         end
     end


### PR DESCRIPTION
This fixes a deprecation in Chef 14
https://docs.chef.io/deprecations_namespace_collisions.html

Current Version results in this Error
```
    ================================================================================
    Error executing action `join` on resource 'zerotier_network[XXXXXXXXXXXXXX]'
    ================================================================================

    NameError
    ---------
    undefined local variable or method `network_id' for #<#<Class:0x00000000044f5908>:0x0000000004d13770>


```

